### PR TITLE
Use similar import style as policy-peoplefinder-rbac

### DIFF
--- a/src/policies/__id/delete.rego
+++ b/src/policies/__id/delete.rego
@@ -1,5 +1,7 @@
 package peoplefinder.DELETE.api.users.__id
 
+import input.user.attributes.properties as user_props
+
 default allowed = false
 
 default visible = false
@@ -7,14 +9,12 @@ default visible = false
 default enabled = false
 
 allowed {
-	props = input.user.attributes.properties
-	props.department == "Operations"
-	props.title == "IT Manager"
+	user_props.department == "Operations"
+	user_props.title == "IT Manager"
 }
 
 visible {
-	props = input.user.attributes.properties
-	props.department == "Operations"
+	user_props.department == "Operations"
 }
 
 enabled {

--- a/src/policies/__id/post.rego
+++ b/src/policies/__id/post.rego
@@ -1,5 +1,7 @@
 package peoplefinder.POST.api.users.__id
 
+import input.user.attributes.properties as user_props
+
 default allowed = false
 
 default visible = true
@@ -7,8 +9,7 @@ default visible = true
 default enabled = false
 
 allowed {
-	props = input.user.attributes.properties
-	props.department == "Operations"
+	user_props.department == "Operations"
 }
 
 enabled {

--- a/src/policies/__id/put.rego
+++ b/src/policies/__id/put.rego
@@ -1,5 +1,7 @@
 package peoplefinder.PUT.api.users.__id
 
+import input.user.attributes.properties as user_props
+
 default allowed = false
 
 default visible = true
@@ -7,8 +9,7 @@ default visible = true
 default enabled = true
 
 allowed {
-	props = input.user.attributes.properties
-	props.department == "Operations"
+	user_props.department == "Operations"
 }
 
 allowed {

--- a/src/policies/post.rego
+++ b/src/policies/post.rego
@@ -1,5 +1,7 @@
 package peoplefinder.POST.api.users
 
+import input.user.attributes.properties as user_props
+
 default allowed = false
 
 default visible = false
@@ -7,9 +9,8 @@ default visible = false
 default enabled = false
 
 allowed {
-	props = input.user.attributes.properties
-	props.department == "Operations"
-	props.title == "IT Manager"
+	user_props.department == "Operations"
+	user_props.title == "IT Manager"
 }
 
 visible {


### PR DESCRIPTION
In `policy-peoplefinder-rbac` we do:
`import input.user.attributes.roles as user_roles`
so this updates the ABAC policy to parallel that one